### PR TITLE
Potential fix for code scanning alert no. 1: Client-side URL redirect

### DIFF
--- a/libs/luci-lib-nixio/axTLS/www/index.html
+++ b/libs/luci-lib-nixio/axTLS/www/index.html
@@ -4256,7 +4256,12 @@ function displayMessage(text,linkText)
 	if(linkText)
 		{
 		var link = createTiddlyElement(e,"a",null,null,text);
-		link.href = linkText;
+		var allowedUrls = ["file://safe/path1", "file://safe/path2"]; // Example whitelist
+		if (allowedUrls.includes(linkText)) {
+			link.href = linkText;
+		} else {
+			link.href = "file://safe/default"; // Safe default value
+		}
 		link.target = "_blank";
 		}
 	else


### PR DESCRIPTION
Potential fix for [https://github.com/Jackie264/luci/security/code-scanning/1](https://github.com/Jackie264/luci/security/code-scanning/1)

To fix the issue, we need to validate the `linkText` value before using it to set the `href` attribute of the link. The best approach is to maintain a whitelist of allowed URLs or paths and ensure that `linkText` matches one of these before assigning it to `link.href`. If `linkText` does not match the whitelist, we should either reject it or replace it with a safe default value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
